### PR TITLE
Make index file configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Supported tags and respective `Dockerfile` links:
 | `NGINX_FASTCGI_BUFFER_SIZE`      | `32k`            |             |
 | `NGINX_FASTCGI_INTERCEPT_ERRORS` | `on`             |             |
 | `NGINX_FASTCGI_READ_TIMEOUT`     | `900`            |             |
+| `NGINX_INDEX_FILE`               | `index.php`      |             |
 
 See [wodby/nginx](https://github.com/wodby/nginx) for all variables.
 

--- a/templates/default-vhost.conf.tpl
+++ b/templates/default-vhost.conf.tpl
@@ -13,7 +13,7 @@ server {
     listen       80;
 
     root {{ getenv "NGINX_SERVER_ROOT" "/var/www/html/" }};
-    index index.php;
+    index {{ getenv "NGINX_INDEX_FILE" "index.php" }};
 
     include healthz.conf;
     include fastcgi.conf;
@@ -39,7 +39,7 @@ server {
     }
 
     location / {
-        try_files $uri $uri/ /index.php?$args;
+        try_files $uri $uri/ /{{ getenv "NGINX_INDEX_FILE" "index.php" }}?$args;
     }
 
     location ~ [^/]\.php(/|$) {

--- a/templates/fastcgi.conf.tpl
+++ b/templates/fastcgi.conf.tpl
@@ -33,4 +33,4 @@ fastcgi_buffer_size {{ getenv "NGINX_FASTCGI_BUFFER_SIZE" "32k" }};
 fastcgi_intercept_errors {{ getenv "NGINX_FASTCGI_INTERCEPT_ERRORS" "on" }};
 fastcgi_read_timeout {{ getenv "NGINX_FASTCGI_READ_TIMEOUT" "900" }};
 fastcgi_keep_conn on;
-fastcgi_index index.php;
+fastcgi_index {{ getenv "NGINX_INDEX_FILE" "index.php" }};


### PR DESCRIPTION
Allows for the index file (currently hard-coded to `index.php`) to be configured. For example, in Symfony 3 the entry file is `app.php`.